### PR TITLE
Integrate the "clippy-beta" feature into the github CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -83,6 +83,7 @@ jobs:
         continue-on-error: true
         with:
           name: Clippy (beta)
+          token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features --all-targets -- -W clippy::all
 
       #

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -78,6 +78,13 @@ jobs:
           command: clippy
           args: --all-features -- -D warnings
 
+      - name: Run Clippy (beta)
+        uses: actions-rs/clippy-check@v1
+        continue-on-error: true
+        with:
+          name: Clippy (beta)
+          args: --all-features --all-targets -- -W clippy::all
+
       #
       # Doc & Spec
       #


### PR DESCRIPTION
**What's been done:**
Add the `clippy-check` rust github action to the CI

**Reference:** https://github.com/o1-labs/proof-systems/issues/855